### PR TITLE
Add drivemode for alternate function

### DIFF
--- a/source/GpioPinDriveMode.cs
+++ b/source/GpioPinDriveMode.cs
@@ -41,6 +41,10 @@ namespace Windows.Devices.Gpio
         /// <summary>
         /// Configures the GPIO pin in open collector mode with resistive pull-down mode.
         /// </summary>
-        OutputOpenSourcePullDown
+        OutputOpenSourcePullDown,
+        /// <summary>
+        /// Configures the GPIO pin for an alternate function
+        /// </summary>
+        Alternate
     }
 }


### PR DESCRIPTION
## Description
This permits to set a pin to an alternate function (e.g. PWM, ADC)

## Motivation and Context
Will enable users to select a function other than input/output for a pin.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

