### PR TITLE
Setting Gpio alternate funcion is now an extension

### DIFF
--- a/source/Extensions/Gpio​PinExtensions.cs
+++ b/source/Extensions/Gpio​PinExtensions.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2017 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Windows.Devices.Gpio
+{
+    /// <summary>
+    /// nanoFramework extensions for <see cref="GpioPin"/>.
+    /// </summary>
+    public static class Gpio​PinExtensions
+    {
+        /// <summary>
+        /// Sets the pin to the specified alternate function.
+        /// </summary>
+        /// <param name="pin"></param>
+        /// <param name="alternateFunction">The value of the alternate function.</param>
+        /// <remarks>
+        /// This extension is exclusive of nanoFramework and it may not be supported in all platforms.
+        /// WARNING: Use with caution! There is no validation on the execution of this call and there is the potential for breaking things, 
+        /// so be sure to know what you are doing when using it.
+        /// Platforms supporting this feature: Cortex-M and ESP32.
+        /// Platforms not supporting this feature: none.
+        /// </remarks>
+        public static void SetAlternateFunction(this Gpio​Pin pin, int alternateFunction)
+        {
+            pin.NativeSetAlternateFunction(alternateFunction);
+        }
+    }
+}

--- a/source/GpioPinDriveMode.cs
+++ b/source/GpioPinDriveMode.cs
@@ -41,10 +41,6 @@ namespace Windows.Devices.Gpio
         /// <summary>
         /// Configures the GPIO pin in open collector mode with resistive pull-down mode.
         /// </summary>
-        OutputOpenSourcePullDown,
-        /// <summary>
-        /// Configures the GPIO pin for an alternate function
-        /// </summary>
-        Alternate
+        OutputOpenSourcePullDown
     }
 }

--- a/source/Gpio​Pin.cs
+++ b/source/Gpio​Pin.cs
@@ -27,7 +27,6 @@ namespace Windows.Devices.Gpio
         private object _syncLock = new object();
 
         private readonly int _pinNumber;
-        private int _alternateFunction = 0;
         private GpioPinDriveMode _driveMode = GpioPinDriveMode.Input;
         private TimeSpan _debounceTimeout = TimeSpan.Zero;
         private GpioPinValueChangedEventHandler _callbacks = null;
@@ -156,21 +155,18 @@ namespace Windows.Devices.Gpio
         /// <item><term>E_ACCESSDENIED : The pin is open in shared read-only mode.Close the pin and reopen it in exclusive mode to change the drive mode of the pin.</term></item>
         /// </list>
         /// </remarks>
-        public void SetDriveMode(GpioPinDriveMode value, int alternateFunction = 0)
+        public void SetDriveMode(GpioPinDriveMode value)
         {
             lock (_syncLock)
             {
                 // check if pin has been disposed
                 if (_disposedValue) { throw new ObjectDisposedException(); }
 
-                if (_driveMode == value && alternateFunction == _alternateFunction) return;
-
                 // check if the request drive mode is supported
                 // need to call the native method directly because we are already inside a lock
                 if (NativeIsDriveModeSupported(value))
                 {
-                    NativeSetDriveMode(value, alternateFunction);
-                    _alternateFunction = alternateFunction;
+                    NativeSetDriveMode(value);
                     _driveMode = value;
                 }
             }
@@ -249,7 +245,7 @@ namespace Windows.Devices.Gpio
                     try
                     {
                         _callbacks = callbacksNew;
-                        NativeSetDriveMode(_driveMode, _alternateFunction);
+                        NativeSetDriveMode(_driveMode);
                     }
                     catch
                     {
@@ -274,7 +270,7 @@ namespace Windows.Devices.Gpio
                     try
                     {
                         _callbacks = callbacksNew;
-                        NativeSetDriveMode(_driveMode, _alternateFunction);
+                        NativeSetDriveMode(_driveMode);
                     }
                     catch
                     {
@@ -348,13 +344,13 @@ namespace Windows.Devices.Gpio
 
         #endregion
 
-        #region extenal calls to native implementations
+        #region external calls to native implementations
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern bool NativeIsDriveModeSupported(GpioPinDriveMode driveMode);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern void NativeSetDriveMode(GpioPinDriveMode driveMode, int alternateFunction);
+        private extern void NativeSetDriveMode(GpioPinDriveMode driveMode);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern bool NativeInit(int pinNumber);
@@ -364,6 +360,9 @@ namespace Windows.Devices.Gpio
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void WriteNative(GpioPinValue value);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        internal extern void NativeSetAlternateFunction(int alternateFunction);
 
         #endregion
     }

--- a/source/Windows.Devices.Gpio.nfproj
+++ b/source/Windows.Devices.Gpio.nfproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="Extensions\Gpio​PinExtensions.cs" />
     <Compile Include="GpioOpenStatus.cs" />
     <Compile Include="GpioPinDriveMode.cs" />
     <Compile Include="GpioPinEdge.cs" />


### PR DESCRIPTION
## Description
- Extracted this from SetDriveMode to an extension.
- Remove Alternate from GpioPinDriveMode enum.
- Requires image v0.1.0-preview460.

## Motivation and Context
- Improves "separation of concerns" principle by separating the setting of the alternate function from the setting of the drive mode.
- Provides the setting of the alternate function on a extension making it formally more clear its intent.
- Fixes nanoframework/Home#282.


## How Has This Been Tested?<!-- (if applicable) -->
- Successfully running Gpio+Events app from samples repo.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
