### PR TITLE
Fix GpioPin.Write

### DIFF
--- a/source/Gpio​Pin.cs
+++ b/source/Gpio​Pin.cs
@@ -209,20 +209,17 @@ namespace Windows.Devices.Gpio
                     // native write
                     WriteNative(value);
 
-                    // update memory field
-                    _lastOutputValue = value;
-
                     // trigger the pin value changed event, if any is set
                     GpioPinValueChangedEventHandler callbacks = _callbacks;
 
-                    if (_lastOutputValue == GpioPinValue.High)
+                    if (_lastOutputValue == GpioPinValue.Low)
                     {
-                        // last value is HIGH, so now it's LOW
+                        // last value is now LOW, so it was HIGH
                         callbacks?.Invoke(this, new GpioPinValueChangedEventArgs(GpioPinEdge.FallingEdge));
                     }
                     else
                     {
-                        // last value is LOW, so now it's HIGH
+                        // last value is now HIGH, so it was LOW
                         callbacks?.Invoke(this, new GpioPinValueChangedEventArgs(GpioPinEdge.RisingEdge));
                     }
                 }


### PR DESCRIPTION

## Description
- A wrong check was being made on the lastOutputValue field.
- The field lastOutputValue was being set after the native call unnecessarily 

## Motivation and Context


## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
