### PR TITLE
Add lazy initialization to SerialController

### DIFF
--- a/source/Windows.Devices.Gpio/GpioController.cs
+++ b/source/Windows.Devices.Gpio/GpioController.cs
@@ -13,8 +13,13 @@ namespace Windows.Devices.Gpio
     /// <remarks>To get a <see cref="Gpio​Controller"/> object, use the <see cref="GetDefault"/> method.</remarks>
     public sealed class Gpio​Controller : IGpioController
     {
+        // this is used as the lock object 
+        // a lock is required because multiple threads can access the I2C controller
+        readonly static object _syncLock = new object();
+
         // we can have only one instance of the GpioController
-        private static GpioController s_instance = new GpioController();
+        // need to do a lazy initialization of this field to make sure it exists when called elsewhere.
+        private static GpioController s_instance;
 
         /// <summary>
         /// Gets the number of pins on the general-purpose I/O (GPIO) controller.
@@ -49,6 +54,17 @@ namespace Windows.Devices.Gpio
         /// <returns>The default GPIO controller for the system, or null if the system has no GPIO controller.</returns>
         public static Gpio​Controller GetDefault()
         {
+            if (s_instance == null)
+            {
+                lock (_syncLock)
+                {
+                    if (s_instance == null)
+                    {
+                        s_instance = new Gpio​Controller();
+                    }
+                }
+            }
+
             return s_instance;
         }
 


### PR DESCRIPTION
## Description
- Add lazy initialization to SerialController.

## Motivation and Context
- Make sure that the variables do exist when being used. Using the previous code was causing issues because on occasions the types could still be unresolved.
- Addresses nanoFramework/Home#383.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
