### PR TITLE
Static field objects are now created on constructor.

### DIFF
--- a/source/Windows.Devices.Gpio/GpioController.cs
+++ b/source/Windows.Devices.Gpio/GpioController.cs
@@ -15,7 +15,7 @@ namespace Windows.Devices.Gpio
     {
         // this is used as the lock object 
         // a lock is required because multiple threads can access the I2C controller
-        readonly static object _syncLock = new object();
+        static object _syncLock;
 
         // we can have only one instance of the GpioController
         // need to do a lazy initialization of this field to make sure it exists when called elsewhere.
@@ -56,6 +56,11 @@ namespace Windows.Devices.Gpio
         {
             if (s_instance == null)
             {
+                if (_syncLock == null)
+                {
+                    _syncLock = new object();
+                }
+
                 lock (_syncLock)
                 {
                     if (s_instance == null)

--- a/source/Windows.Devices.Gpio/GpioPin.cs
+++ b/source/Windows.Devices.Gpio/GpioPin.cs
@@ -20,11 +20,11 @@ namespace Windows.Devices.Gpio
     /// </summary>
     public sealed class Gpio​Pin : IGpioPin, IDisposable
     {
-        private static GpioPinEventListener s_eventListener = new GpioPinEventListener();
+        private static GpioPinEventListener s_eventListener;
 
         // this is used as the lock object 
         // a lock is required because multiple threads can access the GpioPin
-        private object _syncLock = new object();
+        private object _syncLock;
 
         private readonly int _pinNumber;
         private GpioPinDriveMode _driveMode = GpioPinDriveMode.Input;
@@ -40,6 +40,9 @@ namespace Windows.Devices.Gpio
         internal Gpio​Pin(int pinNumber)
         {
             _pinNumber = pinNumber;
+
+            s_eventListener = new GpioPinEventListener();
+            _syncLock = new object();
         }
 
         internal bool Init()


### PR DESCRIPTION
## Description
- Static field objects are now created on constructor.

## Motivation and Context
- Creating the static fields objects on the class constructor prevents issues related with using the class or their fields on other static constructor or reference because of the dependencies and the order things get initialized in the CLR.
- Fixes nanoframework/Home#453.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
