### PR TITLE
Fix event listener creation on GpioPin

### DIFF
--- a/source/Windows.Devices.Gpio/GpioPin.cs
+++ b/source/Windows.Devices.Gpio/GpioPin.cs
@@ -41,8 +41,15 @@ namespace Windows.Devices.Gpio
         {
             _pinNumber = pinNumber;
 
-            s_eventListener = new GpioPinEventListener();
             _syncLock = new object();
+
+            lock (_syncLock)
+            {
+                if (s_eventListener == null)
+                {
+                    s_eventListener = new GpioPinEventListener();
+                }
+            }
         }
 
         internal bool Init()


### PR DESCRIPTION
## Description
- The event listener was being wrongly created for each GpioPin created.

## Motivation and Context
- Fixes nanoFramework/Home#460.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
