### PR TITLE
Rework GpioChangeCounter Read

### DIFF
--- a/source/Windows.Devices.Gpio/Gpio​Change​Counter.cs
+++ b/source/Windows.Devices.Gpio/Gpio​Change​Counter.cs
@@ -28,7 +28,6 @@ namespace Windows.Devices.Gpio
         private bool _inputMode;
         private GpioChangePolarity _polarity = GpioChangePolarity.Falling;
         private bool _countActive = false;
-        private TimeSpan _readTime;
 
         // this is used as the lock object 
         // a lock is required because multiple threads can access the Gpio​Change​Counter
@@ -51,10 +50,10 @@ namespace Windows.Devices.Gpio
         {
             if ( pin.SharingMode != GpioSharingMode.Exclusive )
             {
-                throw new  ArgumentException();             }
+                throw new  ArgumentException();
+            }
 
             _pinNumber = pin.PinNumber;
-            _readTime = new TimeSpan(0);
 
             _inputMode = (pin.GetDriveMode() < GpioPinDriveMode.Output );
 
@@ -114,20 +113,16 @@ namespace Windows.Devices.Gpio
 
         internal GpioChangeCount ReadInternal(bool reset)
         {
-            GpioChangeCount ChangeCount = new GpioChangeCount();
+            GpioChangeCount changeCount;
 
             lock (_syncLock)
             {
                 if (_disposedValue) { throw new ObjectDisposedException(); }
 
-                ChangeCount.Count = NativeRead(reset);
-
-                // _readTime is filled by the NativeRead()
-                ChangeCount.RelativeTime = _readTime;
+                changeCount = NativeRead(reset);
             }
-            return ChangeCount;
+            return changeCount;
         }
-
 
         /// <summary>
         /// Resets the count to 0 and returns the previous count.
@@ -249,7 +244,7 @@ namespace Windows.Devices.Gpio
         private extern void NativeInit();
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        private extern ulong NativeRead(bool Reset);
+        private extern GpioChangeCount NativeRead(bool Reset);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private extern void NativeStart();

--- a/source/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
+++ b/source/Windows.Devices.Gpio/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Runtime.InteropServices;
 
 ////////////////////////////////////////////////////////////////
 // update this whenever the native assembly signature changes //
-[assembly: AssemblyNativeVersion("100.1.2.1")]
+[assembly: AssemblyNativeVersion("100.1.2.2")]
 ////////////////////////////////////////////////////////////////
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4.1-preview.{height}",
+  "version": "1.4.2-preview.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
## Description
- Replace return of native call with ChangeCount.
- Remove unnecessary field.
- Bump AssemblyNativeVersion to 100.1.2.2.
- Bump version to 1.4.2-preview.

## Motivation and Context
- Fixes nanoFramework/Home#598.

## How Has This Been Tested?<!-- (if applicable) -->
- Smoke test from code in the issue above.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
